### PR TITLE
fix(ci): run all tests with testFull instead of test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}; githubWorkflowCheck'
 
       - name: Build project
-        run: sbt '++ ${{ matrix.scala }}; test'
+        run: sbt '++ ${{ matrix.scala }}; testFull'
 
   publish:
     name: Publish Artifacts

--- a/build.sbt
+++ b/build.sbt
@@ -99,3 +99,11 @@ ThisBuild / githubWorkflowPublish := Seq(
 // artifact upload steps embed whichever Scala version is active. That makes
 // githubWorkflowCheck fail in every cross-build job but one.
 ThisBuild / githubWorkflowArtifactUpload := false
+
+// In sbt 2, `test` only runs tests that failed before, were not run, or whose
+// dependencies changed. Its results are cached in ~/.cache/sbt, which CI
+// restores across runs, so a job can report success having run nothing.
+// `testFull` runs every test.
+ThisBuild / githubWorkflowBuild := Seq(
+  WorkflowStep.Sbt(List("testFull"), name = Some("Build project"))
+)


### PR DESCRIPTION
sbt 2 redefined `test` to mean what `testQuick` meant in sbt 1: run only tests that failed before, were not run, or whose dependencies changed. `testQuick` is now an alias for `test`, and `testFull` is what runs everything.

Results are cached in ~/.cache/sbt, which sbt/setup-sbt restores across runs, so the skip survives onto a clean runner and a job can report success having executed no tests at all.